### PR TITLE
Typo in interval regular expression.

### DIFF
--- a/include/tachyon.h
+++ b/include/tachyon.h
@@ -121,8 +121,8 @@ const uint32_t    TACHYON_MAGIC_HEADER_LENGTH = 8;
 /*------   Regular expression patterns  ------*/
 const std::regex YON_REGEX_CANONICAL_BASES = std::regex("^[ATGC]+$");
 const std::regex YON_REGEX_CONTIG_ONLY     = std::regex("^[A-Za-z0-9\\-_]+$");
-const std::regex YON_REGEX_CONTIG_POSITION = std::regex("^[A-Za-z0-9\\-_]+\\:[0-9]+([\\.]{1}[0-9]+) {0,1}([eE]{1}[0-9]{1})?$");
-const std::regex YON_REGEX_CONTIG_RANGE    = std::regex("^[A-Za-z0-9\\-_]+\\:[0-9]+([\\.]{1}[0-9]+) {0,1}([eE]{1}[0-9]{1})?\\-[0-9]+([\\.]{1}[0-9]+) {0,1}([eE]{1}[0-9]{1})?$");
+const std::regex YON_REGEX_CONTIG_POSITION = std::regex("^[A-Za-z0-9\\-_]+\\:[0-9]+([\\.]{1}[0-9]+){0,1}([eE]{1}[0-9]{1})?$");
+const std::regex YON_REGEX_CONTIG_RANGE    = std::regex("^[A-Za-z0-9\\-_]+\\:[0-9]+([\\.]{1}[0-9]+){0,1}([eE]{1}[0-9]{1})?\\-[0-9]+([\\.]{1}[0-9]+){0,1}([eE]{1}[0-9]{1})?$");
 const std::regex YON_REGEX_PACKED_ALLELES  = std::regex("^([ATGCN\\.]{1}) {1}|(<NON_REF>) {1}$");
 
 /*------   EOF markers   ------*/


### PR DESCRIPTION
Fix a problem with slicing intervals caused by accidental white space in regular expression declarations.